### PR TITLE
Add simplified-to-traditional converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,14 @@ python s2t_batch.py INPUT_DIR OUTPUT_DIR
 ```
 
 Converted files will be written to `OUTPUT_DIR` with the same file names.
+
+## Drag-and-drop GUI
+
+For quick conversion of individual `.srt` subtitle files, a simple GUI is provided.
+Run the script and drag an `.srt` file onto the window (or click to browse):
+
+```bash
+python s2t_gui.py
+```
+
+The converted subtitle will be saved next to the original file with a `_trad.srt` suffix.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# -
+# Simplified to Traditional Chinese Batch Converter
+
+This repository contains a simple Python script to batch convert text files from simplified Chinese to traditional Chinese using [OpenCC](https://github.com/BYVoid/OpenCC).
+
+## Requirements
+
+- Python 3
+- `opencc-python-reimplemented` package
+
+Install dependencies with:
+
+```bash
+pip install opencc-python-reimplemented
+```
+
+## Usage
+
+Prepare a directory with `.txt` files written in simplified Chinese. Run the script with the input and output directories:
+
+```bash
+python s2t_batch.py INPUT_DIR OUTPUT_DIR
+```
+
+Converted files will be written to `OUTPUT_DIR` with the same file names.

--- a/s2t_batch.py
+++ b/s2t_batch.py
@@ -1,0 +1,23 @@
+import argparse
+import pathlib
+from opencc import OpenCC
+
+
+def convert_directory(input_dir: pathlib.Path, output_dir: pathlib.Path) -> None:
+    cc = OpenCC('s2t')  # Simplified Chinese to Traditional Chinese
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for path in input_dir.glob('*.txt'):
+        traditional = cc.convert(path.read_text(encoding='utf-8'))
+        (output_dir / path.name).write_text(traditional, encoding='utf-8')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Batch convert Simplified Chinese text files to Traditional Chinese')
+    parser.add_argument('input_dir', type=pathlib.Path, help='Directory with Simplified Chinese text files')
+    parser.add_argument('output_dir', type=pathlib.Path, help='Directory to write Traditional Chinese text files to')
+    args = parser.parse_args()
+    convert_directory(args.input_dir, args.output_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/s2t_gui.py
+++ b/s2t_gui.py
@@ -1,0 +1,65 @@
+import pathlib
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+try:
+    from tkinterdnd2 import TkinterDnD, DND_FILES
+except ImportError:  # tkinterdnd2 not installed
+    TkinterDnD = None
+    DND_FILES = None
+
+from opencc import OpenCC
+
+
+def convert_srt(path: pathlib.Path) -> pathlib.Path:
+    """Convert a single SRT file to Traditional Chinese.
+
+    Returns the path to the converted file.
+    """
+    cc = OpenCC("s2t")
+    traditional = cc.convert(path.read_text(encoding="utf-8"))
+    output_path = path.with_name(path.stem + "_trad.srt")
+    output_path.write_text(traditional, encoding="utf-8")
+    return output_path
+
+
+def handle_file(path: str):
+    p = pathlib.Path(path)
+    if p.suffix.lower() != ".srt":
+        messagebox.showerror("Error", "Please provide an .srt file")
+        return
+    try:
+        out = convert_srt(p)
+    except Exception as e:
+        messagebox.showerror("Conversion failed", str(e))
+        return
+    messagebox.showinfo("Done", f"Converted file saved to {out}")
+
+
+def main():
+    if TkinterDnD:
+        root = TkinterDnD.Tk()
+    else:
+        root = tk.Tk()
+    root.title("SRT Simplified->Traditional Converter")
+    root.geometry("400x200")
+
+    label = tk.Label(root, text="Drag SRT file here or click to browse", relief="ridge", width=40, height=5)
+    label.pack(expand=True, padx=20, pady=20, fill="both")
+
+    def browse():
+        path = filedialog.askopenfilename(filetypes=[("SRT files", "*.srt")])
+        if path:
+            handle_file(path)
+
+    label.bind("<Button-1>", lambda _: browse())
+
+    if TkinterDnD and DND_FILES:
+        label.drop_target_register(DND_FILES)
+        label.dnd_bind("<<Drop>>", lambda e: handle_file(e.data))
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple Python tool `s2t_batch.py` for batch conversion
- document usage in README

## Testing
- `python3 -m py_compile s2t_batch.py`

------
https://chatgpt.com/codex/tasks/task_e_6847c473b768832aa089b3f2b6769cc2